### PR TITLE
pypdfium2: just forward input to PdfDocument directly

### DIFF
--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -201,13 +201,7 @@ class PyPdfiumPageBackend(PdfPageBackend):
 class PyPdfiumDocumentBackend(PdfDocumentBackend):
     def __init__(self, path_or_stream: Iterable[Union[BytesIO, Path]]):
         super().__init__(path_or_stream)
-
-        if isinstance(path_or_stream, Path):
-            self._pdoc = pdfium.PdfDocument(path_or_stream)
-        elif isinstance(path_or_stream, BytesIO):
-            self._pdoc = pdfium.PdfDocument(
-                path_or_stream
-            )  # TODO Fix me, won't accept bytes.
+        self._pdoc = pdfium.PdfDocument(path_or_stream)
 
     def page_count(self) -> int:
         return len(self._pdoc)


### PR DESCRIPTION
[`PdfDocument`](https://pypdfium2.readthedocs.io/en/stable/python_api.html#pypdfium2._helpers.document.PdfDocument) should do accept strings, paths, bytes and byte streams. If not, please file a bug report.