### PR TITLE
fix: refine conversion result

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ To convert invidual PDF documents, use `convert_single()`, for example:
 ```python
 from docling.document_converter import DocumentConverter
 
-source = "https://arxiv.org/pdf/2206.01062"  # PDF path or URL
+source = "https://arxiv.org/pdf/2408.09869"  # PDF path or URL
 converter = DocumentConverter()
-doc = converter.convert_single(source)
-print(doc.render_as_markdown())  # output: "## DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis [...]"
+result = converter.convert_single(source)
+print(result.render_as_markdown())  # output: "## Docling Technical Report[...]"
 ```
 
 ### Convert a batch of documents
@@ -118,7 +118,7 @@ You can convert PDFs from a binary stream instead of from the filesystem as foll
 buf = BytesIO(your_binary_stream)
 docs = [DocumentStream(filename="my_doc.pdf", stream=buf)]
 conv_input = DocumentConversionInput.from_streams(docs)
-converted_docs = doc_converter.convert(conv_input)
+results = doc_converter.convert(conv_input)
 ```
 ### Limit resource usage
 

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -247,9 +247,9 @@ PageElement = Union[TextElement, TableElement, FigureElement]
 
 
 class AssembledUnit(BaseModel):
-    elements: List[PageElement]
-    body: List[PageElement]
-    headers: List[PageElement]
+    elements: List[PageElement] = []
+    body: List[PageElement] = []
+    headers: List[PageElement] = []
 
 
 class Page(BaseModel):

--- a/docling/models/ds_glm_model.py
+++ b/docling/models/ds_glm_model.py
@@ -10,7 +10,7 @@ from docling_core.types import Ref
 from PIL import ImageDraw
 
 from docling.datamodel.base_models import BoundingBox, Cluster, CoordOrigin
-from docling.datamodel.document import ConvertedDocument
+from docling.datamodel.document import ConversionResult
 
 
 class GlmModel:
@@ -20,8 +20,8 @@ class GlmModel:
         model = init_nlp_model(model_names="language;term;reference")
         self.model = model
 
-    def __call__(self, document: ConvertedDocument) -> DsDocument:
-        ds_doc = document.to_ds_document()
+    def __call__(self, conv_res: ConversionResult) -> DsDocument:
+        ds_doc = conv_res._to_ds_document()
         ds_doc_dict = ds_doc.model_dump(by_alias=True)
 
         glm_doc = self.model.apply_on_doc(ds_doc_dict)
@@ -34,7 +34,7 @@ class GlmModel:
         # DEBUG code:
         def draw_clusters_and_cells(ds_document, page_no):
             clusters_to_draw = []
-            image = copy.deepcopy(document.pages[page_no].image)
+            image = copy.deepcopy(conv_res.pages[page_no].image)
             for ix, elem in enumerate(ds_document.main_text):
                 if isinstance(elem, BaseText):
                     prov = elem.prov[0]
@@ -56,7 +56,7 @@ class GlmModel:
                             bbox=BoundingBox.from_tuple(
                                 coord=prov.bbox,
                                 origin=CoordOrigin.BOTTOMLEFT,
-                            ).to_top_left_origin(document.pages[page_no].size.height),
+                            ).to_top_left_origin(conv_res.pages[page_no].size.height),
                         )
                     )
 

--- a/examples/export_figures.py
+++ b/examples/export_figures.py
@@ -10,7 +10,7 @@ from docling.datamodel.base_models import (
     PageElement,
     TableElement,
 )
-from docling.datamodel.document import ConvertedDocument, DocumentConversionInput
+from docling.datamodel.document import DocumentConversionInput
 from docling.document_converter import DocumentConverter
 
 _log = logging.getLogger(__name__)
@@ -39,25 +39,25 @@ def main():
 
     start_time = time.time()
 
-    converted_docs = doc_converter.convert(input_files)
+    conv_results = doc_converter.convert(input_files)
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    for doc in converted_docs:
-        if doc.status != ConversionStatus.SUCCESS:
-            _log.info(f"Document {doc.input.file} failed to convert.")
+    for conv_res in conv_results:
+        if conv_res.status != ConversionStatus.SUCCESS:
+            _log.info(f"Document {conv_res.input.file} failed to convert.")
             continue
 
-        doc_filename = doc.input.file.stem
+        doc_filename = conv_res.input.file.stem
 
         # Export page images
-        for page in doc.pages:
+        for page in conv_res.pages:
             page_no = page.page_no + 1
             page_image_filename = output_dir / f"{doc_filename}-{page_no}.png"
             with page_image_filename.open("wb") as fp:
                 page.image.save(fp, format="PNG")
 
         # Export figures and tables
-        for element, image in doc.render_element_images(
+        for element, image in conv_res.render_element_images(
             element_types=(FigureElement, TableElement)
         ):
             element_image_filename = (


### PR DESCRIPTION
- fields `output` and `assembled` need not be optional
- introduced "synonym" `ConversionResult` for `ConvertedDocument` and deprecated the latter