### PR TITLE
 fix: ensure PDF backend resources are cleaned up in case of failures

### DIFF
--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -199,9 +199,6 @@ class DocumentConverter:
                 end_pb_time = time.time() - start_pb_time
                 _log.info(f"Finished converting page batch time={end_pb_time:.3f}")
 
-            # Free up mem resources of PDF backend
-            in_doc._backend.unload()
-
             conv_res.pages = all_assembled_pages
             self._assemble_doc(conv_res)
 
@@ -226,6 +223,11 @@ class DocumentConverter:
                 f"Encountered an error during conversion of document {in_doc.document_hash}:\n"
                 f"{trace}"
             )
+
+        finally:
+            # Always unload the PDF backend, even in case of failure
+            if in_doc._backend:
+                in_doc._backend.unload()
 
         end_doc_time = time.time() - start_doc_time
         _log.info(


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->
**Description of Changes**:
This PR ensures that the PDF backend resources are properly cleaned up in case of failures by moving the resource cleanup into a `finally` block.

**Issue resolved by this Pull Request:**
Resolves #127

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
