### PR TITLE
ci: run ci also on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,31 +14,11 @@ env:
   PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
 
 jobs:
-  debug:
-    runs-on: ubuntu-latest
-    steps:
-      - name: print 1
-        run: echo "${{ github.event_name }}"
-      - name: print 1a
-        run: echo "${{ github.event_name == 'push' }}"
-      - name: print 2
-        run: echo "${{ github.event.pull_request.head.repo.full_name }}"
-      - name: print 2a
-        run: echo "${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}"
-      - name: print 2b
-        run: echo "${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}"
-      - name: print 2c
-        run: echo "${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' && github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}"
-  to-skip:
+  code-checks:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling') }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "I was here... event_name=${{ github.event_name }}" 
-  # code-checks:
-  #   if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
-  #   uses: ./.github/workflows/checks.yml
-  # build-docs:
-  #   if: false
-  #   uses: ./.github/workflows/docs.yml
-  #   with:
-  #     deploy: false
+    uses: ./.github/workflows/checks.yml
+  build-docs:
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling') }}
+    uses: ./.github/workflows/docs.yml
+    with:
+      deploy: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: "Run CI"
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - "**"
@@ -15,8 +15,10 @@ env:
 
 jobs:
   code-checks:
+    if: ${{ github.event_name == 'push' }} || ${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}
     uses: ./.github/workflows/checks.yml
   build-docs:
+    if: ${{ github.event_name == 'push' }} || ${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,18 @@ jobs:
         run: echo "${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}"
       - name: print 2b
         run: echo "${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}"
-      - name: print 2a
+      - name: print 2c
         run: echo "${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' && github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}"
-  code-checks:
-    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
-    uses: ./.github/workflows/checks.yml
-  build-docs:
-    if: false
-    uses: ./.github/workflows/docs.yml
-    with:
-      deploy: false
+  to-skip:
+    if: ${{ github.event_name == 'push' }} || ${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "I was here..." 
+  # code-checks:
+  #   if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
+  #   uses: ./.github/workflows/checks.yml
+  # build-docs:
+  #   if: false
+  #   uses: ./.github/workflows/docs.yml
+  #   with:
+  #     deploy: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ env:
   PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: print 1
+        run: echo "${{ github.event_name }}"
+      - name: print 2
+        run: echo "${{ github.event.pull_request.head.repo.full_name }}"
   code-checks:
     if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
     uses: ./.github/workflows/checks.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ env:
 
 jobs:
   code-checks:
-    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}) }}
+    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
     uses: ./.github/workflows/checks.yml
   build-docs:
-    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}) }}
+    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
     uses: ./.github/workflows/checks.yml
   build-docs:
-    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
+    if: false
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,21 @@ jobs:
     steps:
       - name: print 1
         run: echo "${{ github.event_name }}"
+      - name: print 1a
+        run: echo "${{ github.event_name == 'push' }}"
       - name: print 2
         run: echo "${{ github.event.pull_request.head.repo.full_name }}"
+      - name: print 2a
+        run: echo "${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}"
+      - name: print 2b
+        run: echo "${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}"
+      - name: print 2a
+        run: echo "${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' && github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}"
   code-checks:
-    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
+    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
     uses: ./.github/workflows/checks.yml
   build-docs:
-    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
+    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       - name: print 2c
         run: echo "${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' && github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}"
   to-skip:
-    if: ${{ github.event_name == 'push' }} || ${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling') }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo "I was here..." 
+      - run: echo "I was here... event_name=${{ github.event_name }}" 
   # code-checks:
   #   if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }})
   #   uses: ./.github/workflows/checks.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ env:
 
 jobs:
   code-checks:
-    if: ${{ github.event_name == 'push' }} || ${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}
+    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}) }}
     uses: ./.github/workflows/checks.yml
   build-docs:
-    if: ${{ github.event_name == 'push' }} || ${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }}
+    if: ${{ github.event_name == 'push' }} || (${{ github.event.pull_request.head.repo.full_name != 'DS4SD/docling' }} && ${{ github.event.pull_request.head.repo.full_name != 'ds4sd/docling' }}) }}
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false


### PR DESCRIPTION
Adding the `synchronize` event, the CI will run on forks. Additionally, with some `if: ` we avoid running the jobs twice, when we are not on a fork.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
