### PR TITLE
feat: add coverage_threshold to skip OCR for small images

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -23,7 +23,7 @@ class TableStructureOptions(BaseModel):
 class OcrOptions(BaseModel):
     kind: str
     coverage_threshold: float = (
-        0.3  # percentage of the area which must be covered by bitmaps for triggering OCR
+        0.05  # percentage of the area for a bitmap to processed with OCR
     )
 
 

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -22,6 +22,9 @@ class TableStructureOptions(BaseModel):
 
 class OcrOptions(BaseModel):
     kind: str
+    coverage_threshold: float = (
+        0.3  # percentage of the area which must be covered by bitmaps for triggering OCR
+    )
 
 
 class EasyOcrOptions(OcrOptions):

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -22,7 +22,7 @@ class TableStructureOptions(BaseModel):
 
 class OcrOptions(BaseModel):
     kind: str
-    coverage_threshold: float = (
+    bitmap_area_threshold: float = (
         0.05  # percentage of the area for a bitmap to processed with OCR
     )
 

--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -68,6 +68,10 @@ class BaseOcrModel:
             bitmap_rects = []
         coverage, ocr_rects = find_ocr_rects(page.size, bitmap_rects)
 
+        # skip OCR if the bitmap area on the page is smaller than the options threshold
+        if coverage < self.options.coverage_threshold:
+            return []
+
         # return full-page rectangle if sufficiently covered with bitmaps
         if coverage > BITMAP_COVERAGE_TRESHOLD:
             return [

--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -68,12 +68,8 @@ class BaseOcrModel:
             bitmap_rects = []
         coverage, ocr_rects = find_ocr_rects(page.size, bitmap_rects)
 
-        # skip OCR if the bitmap area on the page is smaller than the options threshold
-        if coverage < self.options.coverage_threshold:
-            return []
-
         # return full-page rectangle if sufficiently covered with bitmaps
-        if coverage > BITMAP_COVERAGE_TRESHOLD:
+        if coverage > max(BITMAP_COVERAGE_TRESHOLD, self.options.coverage_threshold):
             return [
                 BoundingBox(
                     l=0,
@@ -85,6 +81,14 @@ class BaseOcrModel:
             ]
         # return individual rectangles if the bitmap coverage is smaller
         else:  # coverage <= BITMAP_COVERAGE_TRESHOLD:
+
+            # skip OCR if the bitmap area on the page is smaller than the options threshold
+            ocr_rects = [
+                rect
+                for rect in ocr_rects
+                if rect.area() / (page.size.width * page.size.height)
+                > self.options.coverage_threshold
+            ]
             return ocr_rects
 
     # Filters OCR cells by dropping any OCR cell that intersects with an existing programmatic cell.

--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -69,7 +69,7 @@ class BaseOcrModel:
         coverage, ocr_rects = find_ocr_rects(page.size, bitmap_rects)
 
         # return full-page rectangle if sufficiently covered with bitmaps
-        if coverage > max(BITMAP_COVERAGE_TRESHOLD, self.options.coverage_threshold):
+        if coverage > max(BITMAP_COVERAGE_TRESHOLD, self.options.bitmap_area_threshold):
             return [
                 BoundingBox(
                     l=0,
@@ -87,7 +87,7 @@ class BaseOcrModel:
                 rect
                 for rect in ocr_rects
                 if rect.area() / (page.size.width * page.size.height)
-                > self.options.coverage_threshold
+                > self.options.bitmap_area_threshold
             ]
             return ocr_rects
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -42,3 +42,23 @@ def test_e2e_conversions(test_doc_path):
         doc_result: ConversionResult = converter.convert(test_doc_path)
 
         assert doc_result.status == ConversionStatus.SUCCESS
+
+
+def test_ocr_coverage_threshold(test_doc_path):
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_ocr = True
+    pipeline_options.ocr_options.coverage_threshold = 1.1
+
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options,
+            )
+        }
+    )
+
+    test_doc_path = Path("./tests/data_scanned/ocr_test.pdf")
+    doc_result: ConversionResult = converter.convert(test_doc_path)
+
+    # this should have generated no results, since we set a very high threshold
+    assert len(doc_result.document.texts) == 0

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -47,7 +47,7 @@ def test_e2e_conversions(test_doc_path):
 def test_ocr_coverage_threshold(test_doc_path):
     pipeline_options = PdfPipelineOptions()
     pipeline_options.do_ocr = True
-    pipeline_options.ocr_options.coverage_threshold = 1.1
+    pipeline_options.ocr_options.bitmap_area_threshold = 1.1
 
     converter = DocumentConverter(
         format_options={


### PR DESCRIPTION
New option `pipeline_options.ocr_options.coverage_threshold` which allows to skip OCR on small pictures.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
