### PR TITLE
fix: [Optional] MD backend, handling long sequence of unescaped underscore chars

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import warnings
 from io import BytesIO
 from pathlib import Path
 from typing import Set, Union
@@ -27,7 +28,7 @@ _log = logging.getLogger(__name__)
 
 class MarkdownDocumentBackend(DeclarativeDocumentBackend):
 
-    def shorten_underscore_sequences(self, markdown_text, max_length=4):
+    def shorten_underscore_sequences(self, markdown_text, max_length=10):
         # This regex will match any sequence of underscores
         pattern = r"_+"
 
@@ -44,6 +45,9 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
 
         # Use re.sub to replace long underscore sequences
         shortened_text = re.sub(pattern, replace_match, markdown_text)
+
+        if len(shortened_text) != len(markdown_text):
+            warnings.warn("Detected potentially incorrect Markdown, correcting...")
 
         return shortened_text
 

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -27,6 +27,8 @@ _log = logging.getLogger(__name__)
 class MarkdownDocumentBackend(DeclarativeDocumentBackend):
 
     def clean_md(self, md_text):
+        # Long sequences of unescaped underscore symbols "_" hangs parser
+        # Up to 3 characters "___" are allowed to represent italic, bold, and bold-italic
         res_text = md_text.replace("____", "")
         return res_text
 

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -25,6 +25,11 @@ _log = logging.getLogger(__name__)
 
 
 class MarkdownDocumentBackend(DeclarativeDocumentBackend):
+
+    def clean_md(self, md_text):
+        res_text = md_text.replace("____", "")
+        return res_text
+
     def __init__(self, in_doc: "InputDocument", path_or_stream: Union[BytesIO, Path]):
         super().__init__(in_doc, path_or_stream)
 
@@ -42,11 +47,13 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         try:
             if isinstance(self.path_or_stream, BytesIO):
                 text_stream = self.path_or_stream.getvalue().decode("utf-8")
-                self.markdown = text_stream
+                self.markdown = self.clean_md(text_stream)  # remove invalid sequences
             if isinstance(self.path_or_stream, Path):
                 with open(self.path_or_stream, "r", encoding="utf-8") as f:
                     md_content = f.read()
-                    self.markdown = md_content
+                    self.markdown = self.clean_md(
+                        md_content
+                    )  # remove invalid sequences
             self.valid = True
 
             _log.debug(self.markdown)


### PR DESCRIPTION
- Hanging MD backend conversion with long underscore symbols sequence Issue fixed with this PR
- Fixed handle last hanging inline text element in the document
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
