### PR TITLE
chore: make auto-release on request

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,7 @@
 name: "Run CD"
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   # disable keyring (https://github.com/actions/runner-images/issues/6185):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - "**"
-      - "!main"
       - "!gh-pages"
 
 env:


### PR DESCRIPTION
This change will stop running the CD pipeline on every merge to main. Instead, we will trigger it manually, which allows to group multiple changes in a single release.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
