### PR TITLE
Fix/incorrect spelling of individual in docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 ### Convert a single document
 
-To convert invidual PDF documents, use `convert()`, for example:
+To convert individual PDF documents, use `convert()`, for example:
 
 ```python
 from docling.document_converter import DocumentConverter


### PR DESCRIPTION
Fixed a typo in the `usage.md` document, correcting "Invidual" to "Individual".

Resolves #215 
