### PR TITLE
docs: correct spelling of 'individual'

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 ### Convert a single document
 
-To convert invidual PDF documents, use `convert()`, for example:
+To convert individual PDF documents, use `convert()`, for example:
 
 ```python
 from docling.document_converter import DocumentConverter


### PR DESCRIPTION
Fixed a one-word spelling error in `usage.md` by changing invidual to it's correct form of: individual.

**Issue resolved by this Pull Request:**
Resolves #215 

**Checklist:**
- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
