### PR TITLE
fix: allow mps usage for easyocr

### DIFF
--- a/docling/models/easyocr_model.py
+++ b/docling/models/easyocr_model.py
@@ -31,12 +31,9 @@ class EasyOcrModel(BaseOcrModel):
                     "Alternatively, Docling has support for other OCR engines. See the documentation."
                 )
 
-            use_gpu = (
-                False if torch.backends.mps.is_available() else self.options.use_gpu
-            )
             self.reader = easyocr.Reader(
                 lang_list=self.options.lang,
-                gpu=use_gpu,
+                gpu=self.options.use_gpu,
                 model_storage_directory=self.options.model_storage_directory,
                 download_enabled=self.options.download_enabled,
             )

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -80,6 +80,20 @@ def main():
         }
     )
 
+    # Docling Parse with EasyOCR (CPU only)
+    # ----------------------
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_ocr = True
+    pipeline_options.ocr_options.use_gpu = False
+    pipeline_options.do_table_structure = True
+    pipeline_options.table_structure_options.do_cell_matching = True
+
+    doc_converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+        }
+    )
+
     # Docling Parse with Tesseract
     # ----------------------
     # pipeline_options = PdfPipelineOptions()

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -82,17 +82,17 @@ def main():
 
     # Docling Parse with EasyOCR (CPU only)
     # ----------------------
-    pipeline_options = PdfPipelineOptions()
-    pipeline_options.do_ocr = True
-    pipeline_options.ocr_options.use_gpu = False
-    pipeline_options.do_table_structure = True
-    pipeline_options.table_structure_options.do_cell_matching = True
+    # pipeline_options = PdfPipelineOptions()
+    # pipeline_options.do_ocr = True
+    # pipeline_options.ocr_options.use_gpu = False  # <-- set this.
+    # pipeline_options.do_table_structure = True
+    # pipeline_options.table_structure_options.do_cell_matching = True
 
-    doc_converter = DocumentConverter(
-        format_options={
-            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-        }
-    )
+    # doc_converter = DocumentConverter(
+    #     format_options={
+    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+    #     }
+    # )
 
     # Docling Parse with Tesseract
     # ----------------------


### PR DESCRIPTION
This PR allows the usage of Metal Performance Shaders (MPS) accelerators on Mac for EasyOCR.

EasyOCR has already an internal device choice, see https://github.com/JaidedAI/EasyOCR/blob/master/easyocr/easyocr.py#L72.
Since this is triggered only with the argument `gpu=True`, we should not overwrite it.

Some users encounter issues like the following (specially in GitHub CI):
```
2024-11-08T03:46:47.8493970Z E           RuntimeError: MPS backend out of memory (MPS allocated: 8.00 MB, other allocations: 16.00 KB, max allowed: 7.93 GB). Tried to allocate 256 bytes on shared pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).
```
Unfortunately, this is because GitHub runners are not able to virtualize the MPS accelerators (see [GitHub docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#limitations-for-arm64-macos-runners)).


As a workaround, we suggest the users to turn off the gpu (hence also mps) usage for easyocr with

```py
pipeline_options = PdfPipelineOptions()
pipeline_options.ocr_options.use_gpu = False  # <-- set this.

doc_converter = DocumentConverter(
    format_options={
        InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
    }
)
```


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
