### PR TITLE
feat: expose ocr-lang in CLI

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -129,6 +129,12 @@ def export_documents(
     )
 
 
+def _comma_split(raw: Optional[str]) -> Optional[List[str]]:
+    if raw is None:
+        return None
+    return raw.split(",")
+
+
 @app.command(no_args_is_help=True)
 def convert(
     input_sources: Annotated[
@@ -163,6 +169,13 @@ def convert(
     ocr_engine: Annotated[
         OcrEngine, typer.Option(..., help="The OCR engine to use.")
     ] = OcrEngine.EASYOCR,
+    ocr_lang: Annotated[
+        Optional[str],
+        typer.Option(
+            ...,
+            help="Provide a comma-separated list of languages used by the OCR engine. Note that each OCR engine has different values for the language names.",
+        ),
+    ] = None,
     pdf_backend: Annotated[
         PdfBackend, typer.Option(..., help="The PDF backend to use.")
     ] = PdfBackend.DLPARSE_V1,
@@ -247,6 +260,10 @@ def convert(
             ocr_options = TesseractOcrOptions(force_full_page_ocr=force_ocr)
         case _:
             raise RuntimeError(f"Unexpected OCR engine type {ocr_engine}")
+
+    ocr_lang_list = _comma_split(ocr_lang)
+    if ocr_lang_list is not None:
+        ocr_options.lang = ocr_lang_list
 
     pipeline_options = PdfPipelineOptions(
         do_ocr=ocr,

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import logging
+import re
 import time
 import warnings
 from enum import Enum
@@ -129,10 +130,10 @@ def export_documents(
     )
 
 
-def _comma_split(raw: Optional[str]) -> Optional[List[str]]:
+def _split_list(raw: Optional[str]) -> Optional[List[str]]:
     if raw is None:
         return None
-    return raw.split(",")
+    return re.split(r"[;,]", raw)
 
 
 @app.command(no_args_is_help=True)
@@ -261,7 +262,7 @@ def convert(
         case _:
             raise RuntimeError(f"Unexpected OCR engine type {ocr_engine}")
 
-    ocr_lang_list = _comma_split(ocr_lang)
+    ocr_lang_list = _split_list(ocr_lang)
     if ocr_lang_list is not None:
         ocr_options.lang = ocr_lang_list
 

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -22,6 +22,7 @@ class TableStructureOptions(BaseModel):
 
 class OcrOptions(BaseModel):
     kind: str
+    lang: List[str]
     force_full_page_ocr: bool = False  # If enabled a full page OCR is always applied
     bitmap_area_threshold: float = (
         0.05  # percentage of the area for a bitmap to processed with OCR


### PR DESCRIPTION
This PR adds the `--ocr-lang` option to the docling CLI. Multiple languages are specified as a comma-separated list.

**Issue resolved by this Pull Request:**
Resolves #255, #225


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
