### PR TITLE
docs: fixed typo in v2 example v2

### DIFF
--- a/docs/v2.md
+++ b/docs/v2.md
@@ -152,7 +152,7 @@ conv_result: ConversionResult = doc_converter.convert("https://arxiv.org/pdf/240
 conv_result.document.print_element_tree()
 
 ## Iterate the elements in reading order, including hierachy level:
-for item, level in conv_result.document.iterate_items:
+for item, level in conv_result.document.iterate_items():
     if isinstance(item, TextItem):
         print(item.text)
     elif isinstance(item, TableItem):


### PR DESCRIPTION
Minor fix - documentation example was missing parentheses.