### PR TITLE
fix: propagate document limits to converter

### DIFF
--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -183,7 +183,7 @@ class DocumentConverter:
         )
         conv_input = _DocumentConversionInput(
             path_or_stream_iterator=source,
-            limit=limits,
+            limits=limits,
         )
         conv_res_iter = self._convert(conv_input, raises_on_error=raises_on_error)
         for conv_res in conv_res_iter:


### PR DESCRIPTION
We have a small bug which is not propagating the document limits `max_num_pages` and `max_file_size` to the actual converter.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
