### PR TITLE
fix: force pydantic < 2.10.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3581,10 +3581,10 @@ files = [
 numpy = [
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.21.0", markers = "python_version == \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
-    {version = ">=1.23.5", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\" and python_version < \"3.11\""},
     {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.19.3", markers = "platform_system == \"Linux\" and platform_machine == \"aarch64\" and python_version >= \"3.8\" and python_version < \"3.10\" or python_version > \"3.9\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_system != \"Darwin\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.23.5", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 
 [[package]]
@@ -7353,4 +7353,4 @@ tesserocr = ["tesserocr"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "de2354d1c01d11017a742eb0bf826b08aaaeec5e84f62f0e2101c3bc685b7a6f"
+content-hash = "6772098f9951e636c03d958b81f7df3ae0e8746be558fd031aeaa67f9bb45a79"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [{include = "docling"}]
 # actual dependencies:
 ######################
 python = "^3.9"
-pydantic = "^2.0.0"
+pydantic = ">=2.0.0,<2.10"
 docling-core = "^2.4.0"
 docling-ibm-models = "^2.0.6"
 deepsearch-glm = "^0.26.1"


### PR DESCRIPTION
It seems the new Pydantic 2.10.0 release (16h ago).

Downgrading Pydantic works, and it seems the approach taken by many libraries. See https://github.com/run-llama/llama_index/issues/17016.

**Issue resolved by this Pull Request:**
Resolves #406

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
