### PR TITLE
fix(layout_utils): correct conditional logic in adapt_bbox function

### DIFF
--- a/docling/utils/layout_utils.py
+++ b/docling/utils/layout_utils.py
@@ -388,7 +388,7 @@ def adapt_bbox(raw_cells, cluster, orphan_cell_indices):
             [raw_cells[cid]["bbox"] for cid in cluster["cell_ids"]]
         )
         logger.debug("  New bounding box:" + str(new_bbox))
-    if cluster["type"] == DocItemLabel.PICTURE:
+    elif cluster["type"] == DocItemLabel.PICTURE:
         ## We only make the bbox completely comprise included text cells:
         logger.debug("  Picture")
         if len(cluster["cell_ids"]) != 0:


### PR DESCRIPTION
The second 'if' statement in the `adapt_bbox` function was changed to 'elif'
to properly handle the conditional flow for different DocItemLabel types.

This change ensures that the function correctly processes TABLE, PICTURE,
and other DocItemLabel types as intended.

Resolves: #362

**Checklist:**
- [ ] Commit Message Formatting: Commit titles and messages follow guidelines in the
[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
