### PR TITLE
fix: Skip NavigableString in HTML parsing

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Set, Union
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString
 from docling_core.types.doc import (
     DocItemLabel,
     DoclingDocument,
@@ -92,6 +92,8 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         try:
             # Iterate over elements in the body of the document
             for idx, element in enumerate(element.children):
+                if isinstance(element, NavigableString):
+                    continue  # Skip over navigable strings
                 try:
                     self.analyse_element(element, idx, doc)
                 except Exception as exc_child:


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
This PR skips NavigableString elements during HTML parsing to avoid unwanted error.

**Issue resolved by this Pull Request:**
Resolves #463

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
