### PR TITLE
fix: PermissionError when using tesseract_ocr_cli_model

### DIFF
--- a/docling/models/tesseract_ocr_cli_model.py
+++ b/docling/models/tesseract_ocr_cli_model.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import os
 import tempfile
 from subprocess import DEVNULL, PIPE, Popen
 from typing import Iterable, Optional, Tuple
@@ -130,14 +131,17 @@ class TesseractOcrCliModel(BaseOcrModel):
                         high_res_image = page._backend.get_page_image(
                             scale=self.scale, cropbox=ocr_rect
                         )
-
-                        with tempfile.NamedTemporaryFile(
-                            suffix=".png", mode="w"
-                        ) as image_file:
-                            fname = image_file.name
-                            high_res_image.save(fname)
+                        try:
+                            with tempfile.NamedTemporaryFile(
+                                suffix=".png", mode="w+b", delete=False
+                            ) as image_file:
+                                fname = image_file.name
+                                high_res_image.save(image_file)
 
                             df = self._run_tesseract(fname)
+                        finally:
+                            if os.path.exists(fname):
+                                os.remove(fname)
 
                         # _log.info(df)
 


### PR DESCRIPTION
- Make sure that the `tesseract_ocr_cli_model.py` does not open the png image file twice (before it was opened once with `tempfile.NamedTemporaryFile`  and again by passing the file name rather than the file object itself to `high_res_image.save`;
- Ensure that `_run_tesseract` is executed after the file is no longer open by python. This otherwise results in a "PermissionError: [Errno 13] Permission denied" error on Windows.

(Replaces https://github.com/DS4SD/docling/pull/430)