### PR TITLE
ci: allow ! in conventionalcommits

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,7 +6,7 @@ merge_protections:
     success_conditions:
       - "title ~=
         ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\
-        \\))?:"
+        \\))?(!)?:"
   - name: Require two reviewer for test updates
     description: When test data is updated, we require two reviewers
     if:


### PR DESCRIPTION
We have to patch the default mergify CI logic in order to allow for major releases.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
