### PR TITLE
feat: Add Easyocr parameter recog_network

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -140,7 +140,7 @@ class EasyOcrOptions(OcrOptions):
     use_gpu: Optional[bool] = None
 
     model_storage_directory: Optional[str] = None
-    recog_network: Optional[str] = 'standard'
+    recog_network: Optional[str] = "standard"
     download_enabled: bool = True
 
     model_config = ConfigDict(

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -140,6 +140,7 @@ class EasyOcrOptions(OcrOptions):
     use_gpu: Optional[bool] = None
 
     model_storage_directory: Optional[str] = None
+    recog_network: Optional[str] = 'standard'
     download_enabled: bool = True
 
     model_config = ConfigDict(

--- a/docling/models/easyocr_model.py
+++ b/docling/models/easyocr_model.py
@@ -66,6 +66,7 @@ class EasyOcrModel(BaseOcrModel):
                 lang_list=self.options.lang,
                 gpu=use_gpu,
                 model_storage_directory=self.options.model_storage_directory,
+                recog_network=self.options.recog_network,
                 download_enabled=self.options.download_enabled,
                 verbose=False,
             )


### PR DESCRIPTION
Adding recog_network parameter of EasyOCR to allow users use their own custom recognition model. 
This one I have apply pre-commit hook `pre-commit run --all-files` so I hope it able to merge now. 


**Issue resolved by this Pull Request:**
Resolves #602 #604 


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
