### PR TITLE
test: generate file from CLI in a temporary directory

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 from docling.cli.main import app
@@ -15,6 +17,11 @@ def test_cli_version():
     assert result.exit_code == 0
 
 
-def test_cli_convert():
-    result = runner.invoke(app, ["./tests/data/2305.03393v1-pg9.pdf"])
+def test_cli_convert(tmp_path):
+    source = "./tests/data/2305.03393v1-pg9.pdf"
+    output = tmp_path / "out"
+    output.mkdir()
+    result = runner.invoke(app, [source, "--output", str(output)])
     assert result.exit_code == 0
+    converted = output / f"{Path(source).stem}.md"
+    assert converted.exists()


### PR DESCRIPTION
This PR addresses the following fix:

The regression test in `tests/test_cli.py` checks if a docling conversion is successful by invoking the command line.
The execution creates a markdown file `2305.03393v1-pg9.md` in the current directory that is not source-controlled. Since it is not necessary to persist this file, this feature is about refactoring the test to ensure that the generated file exists in a temporary directory. After the test finishes, the temporary directory with the markdown file gets automatically deleted.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
