### PR TITLE
docs: Add OpenContracts as an integration

### DIFF
--- a/docs/integrations/opencontracts.md
+++ b/docs/integrations/opencontracts.md
@@ -1,0 +1,10 @@
+Docling is available an ingestion engine for [OpenContracts](https://github.com/JSv4/OpenContracts), allowing you to use Docling's OCR engine(s), chunker(s), labels, etc. and load them into a platform supporting bulk data extraction, text annotating, and question-answering:
+
+- 💻 [GitHub](https://github.com/JSv4/OpenContracts)
+- 📖 [Docs](https://jsv4.github.io/OpenContracts/)]
+
+ #### Docling in Action!
+
+![docling relationships visualized in pdf](https://github.com/JSv4/OpenContracts/blob/main/docs/assets/images/gifs/PDF%20Annotation%20Flow.gif)
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - "🐶 InstructLab": integrations/instructlab.md
     - "Kotaemon": integrations/kotaemon.md
     - "🦙 LlamaIndex": integrations/llamaindex.md
+    - "OpenContracts": integrations/opencontracts.md
     - "Prodigy": integrations/prodigy.md
     - "RHEL AI": integrations/rhel_ai.md
     - "spaCy": integrations/spacy.md


### PR DESCRIPTION
**Description:**

Added [OpenContracts](http://localhost:3000/extracts) to the integration docs. OpenContracts is a bulk document data extraction and annotation platform. We support token-level text annotations as well as relationships between annotations. We've added Docling as one of our supported document parsers and are using it to parse PDFs, incorporating your text annotations and chunks ("relationships" in our ontology) for retrieval and analysis. 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] Documentation has been updated, if necessary.
- [X] Examples have been added, if necessary.
- [X] Tests have been added, if necessary.
