### PR TITLE
fix(msexcel): ignore Mypy checking for _find_images_in_sheet function in msexcel backend

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -26,6 +26,7 @@ _log = logging.getLogger(__name__)
 
 from typing import Any, List
 
+from PIL import Image
 from pydantic import BaseModel
 
 
@@ -326,10 +327,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend):
         self, doc: DoclingDocument, sheet: Worksheet
     ) -> DoclingDocument:
 
-        # FIXME: mypy does not agree with _images ...
-        """
         # Iterate over images in the sheet
-        for idx, image in enumerate(sheet._images):  # Access embedded images
+        for idx, image in enumerate(sheet._images):  # type: ignore
 
             image_bytes = BytesIO(image.ref.blob)
             pil_image = Image.open(image_bytes)
@@ -339,36 +338,32 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend):
                 image=ImageRef.from_pil(image=pil_image, dpi=72),
                 caption=None,
             )
-        """
 
-        # FIXME: mypy does not agree with _charts ...
-        """
-        for idx, chart in enumerate(sheet._charts):  # Access embedded charts
+        for idx, chart in enumerate(sheet._charts):  # type: ignore
             chart_path = f"chart_{idx + 1}.png"
             _log.info(
                 f"Chart found, but dynamic rendering is required for: {chart_path}"
             )
 
             _log.info(f"Chart {idx + 1}:")
-        
+
             # Chart type
             _log.info(f"Type: {type(chart).__name__}")
-            
+
             # Title
             if chart.title:
                 _log.info(f"Title: {chart.title}")
             else:
                 _log.info("No title")
-            
+
             # Data series
             for series in chart.series:
                 _log.info(" => series ...")
                 _log.info(f"Data Series: {series.title}")
                 _log.info(f"Values: {series.values}")
                 _log.info(f"Categories: {series.categories}")
-                
+
             # Position
             # _log.info(f"Anchor Cell: {chart.anchor}")
-        """
 
         return doc


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

- Ignore Mypy checking for _find_images_in_sheet function when handling excel files  in msexcel backend

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
