### PR TITLE
feat: Support cuda:n GPU device allocation

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -39,7 +39,7 @@ class AcceleratorOptions(BaseSettings):
     )
 
     num_threads: int = 4
-    device: str = "auto"
+    device: Union[str, AcceleratorDevice] = "auto"
 
     @field_validator("device")
     def validate_device(cls, value):

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -41,7 +41,7 @@ class AcceleratorOptions(BaseSettings):
     num_threads: int = 4
     device: str = "auto"
 
-    @validator("device")
+    @field_validator("device")
     def validate_device(cls, value):
         # "auto", "cpu", "cuda", "mps", or "cuda:N"
         if value in {d.value for d in AcceleratorDevice} or re.match(
@@ -55,6 +55,15 @@ class AcceleratorOptions(BaseSettings):
     @model_validator(mode="before")
     @classmethod
     def check_alternative_envvars(cls, data: Any) -> Any:
+        r"""
+        Set num_threads from the "alternative" envvar OMP_NUM_THREADS.
+        The alternative envvar is used only if it is valid and the regular envvar is not set.
+
+        Notice: The standard pydantic settings mechanism with parameter "aliases" does not provide
+        the same functionality. In case the alias envvar is set and the user tries to override the
+        parameter in settings initialization, Pydantic treats the parameter provided in __init__()
+        as an extra input instead of simply overwriting the evvar value for that parameter.
+        """
         if isinstance(data, dict):
             input_num_threads = data.get("num_threads")
             if input_num_threads is None:

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import (
+    AnyUrl,
     BaseModel,
     ConfigDict,
     Field,
@@ -66,6 +67,7 @@ class AcceleratorOptions(BaseSettings):
         """
         if isinstance(data, dict):
             input_num_threads = data.get("num_threads")
+            # Check if to set the num_threads from the alternative envvar
             if input_num_threads is None:
                 docling_num_threads = os.getenv("DOCLING_NUM_THREADS")
                 omp_num_threads = os.getenv("OMP_NUM_THREADS")

--- a/docling/models/easyocr_model.py
+++ b/docling/models/easyocr_model.py
@@ -18,7 +18,6 @@ from docling.datamodel.settings import settings
 from docling.models.base_ocr_model import BaseOcrModel
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
-from docling.utils.utils import download_url_with_progress
 
 _log = logging.getLogger(__name__)
 
@@ -56,6 +55,7 @@ class EasyOcrModel(BaseOcrModel):
                         for x in [
                             AcceleratorDevice.CUDA.value,
                             AcceleratorDevice.MPS.value,
+                            "cuda:",
                         ]
                     ]
                 )
@@ -81,40 +81,6 @@ class EasyOcrModel(BaseOcrModel):
                 download_enabled=download_enabled,
                 verbose=False,
             )
-
-    @staticmethod
-    def download_models(
-        detection_models: List[str] = ["craft"],
-        recognition_models: List[str] = ["english_g2", "latin_g2"],
-        local_dir: Optional[Path] = None,
-        force: bool = False,
-        progress: bool = False,
-    ) -> Path:
-        # Models are located in https://github.com/JaidedAI/EasyOCR/blob/master/easyocr/config.py
-        from easyocr.config import detection_models as det_models_dict
-        from easyocr.config import recognition_models as rec_models_dict
-
-        if local_dir is None:
-            local_dir = settings.cache_dir / "models" / EasyOcrModel._model_repo_folder
-
-        local_dir.mkdir(parents=True, exist_ok=True)
-
-        # Collect models to download
-        download_list = []
-        for model_name in detection_models:
-            if model_name in det_models_dict:
-                download_list.append(det_models_dict[model_name])
-        for model_name in recognition_models:
-            if model_name in rec_models_dict["gen2"]:
-                download_list.append(rec_models_dict["gen2"][model_name])
-
-        # Download models
-        for model_details in download_list:
-            buf = download_url_with_progress(model_details["url"], progress=progress)
-            with zipfile.ZipFile(buf, "r") as zip_ref:
-                zip_ref.extractall(local_dir)
-
-        return local_dir
 
     def __call__(
         self, conv_res: ConversionResult, page_batch: Iterable[Page]

--- a/docling/models/easyocr_model.py
+++ b/docling/models/easyocr_model.py
@@ -55,7 +55,6 @@ class EasyOcrModel(BaseOcrModel):
                         for x in [
                             AcceleratorDevice.CUDA.value,
                             AcceleratorDevice.MPS.value,
-                            "cuda:",
                         ]
                     ]
                 )

--- a/docling/utils/accelerator_utils.py
+++ b/docling/utils/accelerator_utils.py
@@ -7,36 +7,62 @@ from docling.datamodel.pipeline_options import AcceleratorDevice
 _log = logging.getLogger(__name__)
 
 
-def decide_device(accelerator_device: AcceleratorDevice) -> str:
+def decide_device(accelerator_device: str) -> str:
     r"""
-    Resolve the device based on the acceleration options and the available devices in the system
+    Resolve the device based on the acceleration options and the available devices in the system.
+
     Rules:
     1. AUTO: Check for the best available device on the system.
     2. User-defined: Check if the device actually exists, otherwise fall-back to CPU
     """
-    cuda_index = 0
     device = "cpu"
 
     has_cuda = torch.backends.cuda.is_built() and torch.cuda.is_available()
     has_mps = torch.backends.mps.is_built() and torch.backends.mps.is_available()
 
-    if accelerator_device == AcceleratorDevice.AUTO:
+    if accelerator_device == AcceleratorDevice.AUTO.value:  # Handle 'auto'
         if has_cuda:
-            device = f"cuda:{cuda_index}"
+            device = "cuda:0"
         elif has_mps:
             device = "mps"
 
+    elif accelerator_device.startswith("cuda"):
+        if has_cuda:
+            # if cuda device index specified extract device id
+            parts = accelerator_device.split(":")
+            if len(parts) == 2 and parts[1].isdigit():
+                # select cuda device's id
+                cuda_index = int(parts[1])
+                if cuda_index < torch.cuda.device_count():
+                    device = f"cuda:{cuda_index}"
+                else:
+                    _log.warning(
+                        "CUDA device 'cuda:%d' is not available. Fall back to 'CPU'.",
+                        cuda_index,
+                    )
+            elif len(parts) == 1:  # just "cuda"
+                device = "cuda:0"
+            else:
+                _log.warning(
+                    "Invalid CUDA device format '%s'. Fall back to 'CPU'",
+                    accelerator_device,
+                )
+        else:
+            _log.warning("CUDA is not available in the system. Fall back to 'CPU'")
+
+    elif accelerator_device == AcceleratorDevice.MPS.value:
+        if has_mps:
+            device = "mps"
+        else:
+            _log.warning("MPS is not available in the system. Fall back to 'CPU'")
+
+    elif accelerator_device == AcceleratorDevice.CPU.value:
+        device = "cpu"
+
     else:
-        if accelerator_device == AcceleratorDevice.CUDA:
-            if has_cuda:
-                device = f"cuda:{cuda_index}"
-            else:
-                _log.warning("CUDA is not available in the system. Fall back to 'CPU'")
-        elif accelerator_device == AcceleratorDevice.MPS:
-            if has_mps:
-                device = "mps"
-            else:
-                _log.warning("MPS is not available in the system. Fall back to 'CPU'")
+        _log.warning(
+            "Unknown device option '%s'. Fall back to 'CPU'", accelerator_device
+        )
 
     _log.info("Accelerator device: '%s'", device)
     return device

--- a/docs/examples/run_with_accelerator.py
+++ b/docs/examples/run_with_accelerator.py
@@ -30,6 +30,11 @@ def main():
     #     num_threads=8, device=AcceleratorDevice.CUDA
     # )
 
+    # easyocr doesnt support cuda:N allocation
+    # accelerator_options = AcceleratorOptions(
+    #     num_threads=8, device="cuda:1"
+    # )
+
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
     pipeline_options.do_ocr = True

--- a/docs/examples/run_with_accelerator.py
+++ b/docs/examples/run_with_accelerator.py
@@ -30,8 +30,8 @@ def main():
     #     num_threads=8, device=AcceleratorDevice.CUDA
     # )
 
-    # easyocr doesnt support cuda:N allocation
-    # accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:0")
+    # easyocr doesnt support cuda:N allocation, defaults to cuda:0
+    # accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:1")
 
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
@@ -57,8 +57,8 @@ def main():
     # List with total time per document
     doc_conversion_secs = conversion_result.timings["pipeline_total"].times
 
-    # md = doc.export_to_markdown()
-    # print(md)
+    md = doc.export_to_markdown()
+    print(md)
     print(f"Conversion secs: {doc_conversion_secs}")
 
 

--- a/docs/examples/run_with_accelerator.py
+++ b/docs/examples/run_with_accelerator.py
@@ -31,11 +31,11 @@ def main():
     # )
 
     # easyocr doesnt support cuda:N allocation, defaults to cuda:0
-    # accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:1")
+    accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:1")
 
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
-    pipeline_options.do_ocr = True
+    pipeline_options.do_ocr = False
     pipeline_options.do_table_structure = True
     pipeline_options.table_structure_options.do_cell_matching = True
 

--- a/docs/examples/run_with_accelerator.py
+++ b/docs/examples/run_with_accelerator.py
@@ -31,9 +31,7 @@ def main():
     # )
 
     # easyocr doesnt support cuda:N allocation
-    # accelerator_options = AcceleratorOptions(
-    #     num_threads=8, device="cuda:1"
-    # )
+    # accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:0")
 
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
@@ -59,8 +57,8 @@ def main():
     # List with total time per document
     doc_conversion_secs = conversion_result.timings["pipeline_total"].times
 
-    md = doc.export_to_markdown()
-    print(md)
+    # md = doc.export_to_markdown()
+    # print(md)
     print(f"Conversion secs: {doc_conversion_secs}")
 
 

--- a/docs/examples/run_with_accelerator.py
+++ b/docs/examples/run_with_accelerator.py
@@ -31,11 +31,11 @@ def main():
     # )
 
     # easyocr doesnt support cuda:N allocation, defaults to cuda:0
-    accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:1")
+    # accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:1")
 
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
-    pipeline_options.do_ocr = False
+    pipeline_options.do_ocr = True
     pipeline_options.do_table_structure = True
     pipeline_options.table_structure_options.do_cell_matching = True
 


### PR DESCRIPTION
This PR is WIP enables the allocation of cuda devices as the current implementation defaults to cuda:0. This enables launching on multi-gpu and not being restricted on cluster systems with device allocation. 

**Note: Further investigation is needed to make easyocr work with cuda:n as easyocr when using GPU it wraps the models in torch.DataParallel, which causes cuda:0 to be utilised.**

- [ ] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
