### PR TITLE
docs: fix links between docs pages

### DIFF
--- a/docs/concepts/chunking.md
+++ b/docs/concepts/chunking.md
@@ -54,12 +54,12 @@ tokens), &
 chunks with same headings & captions) — users can opt out of this step via param
 `merge_peers` (by default `True`)
 
-👉 Example: see  [here](../../examples/hybrid_chunking).
+👉 Example: see  [here](../examples/hybrid_chunking.ipynb).
 
 ## Hierarchical Chunker
 
 The `HierarchicalChunker` implementation uses the document structure information from
-the [`DoclingDocument`](../docling_document) to create one chunk for each individual
+the [`DoclingDocument`](./docling_document.md) to create one chunk for each individual
 detected document element, by default only merging together list items (can be opted out
 via param `merge_list_items`). It also takes care of attaching all relevant document
 metadata, including headers and captions.

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -95,8 +95,8 @@ doc_converter = (
 
 More options are shown in the following example units:
 
-- [run_with_formats.py](../examples/run_with_formats/)
-- [custom_convert.py](../examples/custom_convert/)
+- [run_with_formats.py](examples/run_with_formats.py)
+- [custom_convert.py](examples/custom_convert.py)
 
 ### Converting documents
 
@@ -226,4 +226,4 @@ leverages the new `DoclingDocument` and provides a new, richer chunk output form
 - any applicable headings for context
 - any applicable captions for context
 
-For an example, check out [Chunking usage](../usage/#chunking).
+For an example, check out [Chunking usage](usage.md#chunking).


### PR DESCRIPTION
Fixing some broken links between docs pages (from mkdocs warnings).

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
