### PR TITLE
ci: added action to generate llms.txt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,10 @@ jobs:
         - uses: ./.github/actions/setup-poetry
         - name: Build docs
           run: poetry run mkdocs build --verbose --clean
+        - name: Make docs LLM ready
+          if: inputs.deploy
+          uses: demodrive-ai/llms-txt-action@v1
         - name: Build and push docs
           if: inputs.deploy
-          run: poetry run mkdocs gh-deploy --force
+          run: poetry run mkdocs gh-deploy --force --dirty
  

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
           run: poetry run mkdocs build --verbose --clean
         - name: Make docs LLM ready
           if: inputs.deploy
-          uses: demodrive-ai/llms-txt-action@v1
+          uses: demodrive-ai/llms-txt-action@ad720693843126e6a73910a667d0eba37c1dea4b
         - name: Build and push docs
           if: inputs.deploy
           run: poetry run mkdocs gh-deploy --force --dirty


### PR DESCRIPTION
This PR adds an open-source action to generate necessary llms files to the docs as per the standard.

- Added `demodrive-ai/llms-txt-action@v1` action
- Added `--dirty` flag in gh-deploy to keep the generated files.

**Issue resolved by this Pull Request:**
Resolves #699 


**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
