### PR TITLE
docs: specify docstring types

### DIFF
--- a/docs/reference/docling_document.md
+++ b/docs/reference/docling_document.md
@@ -32,6 +32,7 @@ This is an automatic generated API reference of the DoclingDocument type.
             - CoordOrigin
             - ImageRefMode
             - Size
+        docstring_style: sphinx
         show_if_no_docstring: true
         show_submodules: true
         docstring_section_style: list


### PR DESCRIPTION
The [docstring_style](https://mkdocstrings.github.io/python/usage/configuration/docstrings/#docstring_style) is needed to improve the parsing of the function parameters.

### Before
<img width="794" alt="image" src="https://github.com/user-attachments/assets/0af46fa2-4021-49d6-910e-9f7b24529a93" />


### After
<img width="794" alt="image" src="https://github.com/user-attachments/assets/4971e316-4427-4da4-8e2f-1742afe8d484" />



**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
