### PR TITLE
docs: fix correct Accelerator pipeline options in docs/examples/custom_convert.py

### DIFF
--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel.base_models import InputFormat
-from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.pipeline_options import AcceleratorDevice, AcceleratorOptions, PdfPipelineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.models.ocr_mac_model import OcrMacOptions
 from docling.models.tesseract_ocr_cli_model import TesseractCliOcrOptions
@@ -76,7 +76,7 @@ def main():
     pipeline_options.table_structure_options.do_cell_matching = True
     pipeline_options.ocr_options.lang = ["es"]
     pipeline_options.accelerator_options = AcceleratorOptions(
-        num_threads=4, device=Device.AUTO
+        num_threads=4, device=AcceleratorDevice.AUTO
     )
 
     doc_converter = DocumentConverter(

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel.base_models import InputFormat
-from docling.datamodel.pipeline_options import AcceleratorDevice, AcceleratorOptions, PdfPipelineOptions
+from docling.datamodel.pipeline_options import (
+    AcceleratorDevice,
+    AcceleratorOptions,
+    PdfPipelineOptions,
+)
 from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.models.ocr_mac_model import OcrMacOptions
 from docling.models.tesseract_ocr_cli_model import TesseractCliOcrOptions


### PR DESCRIPTION
fix[docs/examples/custom_convert.py]: Added the missing AcceleratorDevice and AcceleratorOptions functions in the imports and changed Device in the code to the correct AcceleratorDevice.

**Checklist:**

- [ x] Documentation has been updated, if necessary.
- [ x] Examples have been added, if necessary.
- [ x] Tests have been added, if necessary.
