### PR TITLE
feat: add "auto" language for TesseractOcr

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install tesseract
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng tesseract-ocr-fra tesseract-ocr-deu tesseract-ocr-spa libleptonica-dev libtesseract-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng tesseract-ocr-fra tesseract-ocr-deu tesseract-ocr-spa tesseract-ocr-script-latn libleptonica-dev libtesseract-dev pkg-config
       - name: Set TESSDATA_PREFIX
         run: |
           echo "TESSDATA_PREFIX=$(dpkg -L tesseract-ocr-eng | grep tessdata$)" >> "$GITHUB_ENV"

--- a/docling/models/tesseract_ocr_model.py
+++ b/docling/models/tesseract_ocr_model.py
@@ -81,6 +81,8 @@ class TesseractOcrModel(BaseOcrModel):
         if self.reader is not None:
             # Finalize the tesseractAPI
             self.reader.End()
+        for script in self.script_readers:
+            self.script_readers[script].End()
 
     def __call__(
         self, conv_res: ConversionResult, page_batch: Iterable[Page]

--- a/docling/models/tesseract_ocr_model.py
+++ b/docling/models/tesseract_ocr_model.py
@@ -57,6 +57,11 @@ class TesseractOcrModel(BaseOcrModel):
 
             self.script_readers: dict[str, tesserocr.PyTessBaseAPI] = {}
 
+            if any([l.startswith("script/") for l in tesserocr_languages]):
+                self.script_prefix = "script/"
+            else:
+                self.script_prefix = ""
+
             tesserocr_kwargs = {
                 "psm": tesserocr.PSM.AUTO,
                 "init": True,
@@ -138,7 +143,7 @@ class TesseractOcrModel(BaseOcrModel):
                             if script not in self.script_readers:
                                 self.script_readers[script] = tesserocr.PyTessBaseAPI(
                                     path=self.reader.GetDatapath(),
-                                    lang=f"script/{script}",
+                                    lang=f"{self.script_prefix}{script}",
                                     psm=tesserocr.PSM.AUTO,
                                     init=True,
                                     oem=tesserocr.OEM.DEFAULT,

--- a/tests/test_e2e_ocr_conversion.py
+++ b/tests/test_e2e_ocr_conversion.py
@@ -60,6 +60,7 @@ def test_e2e_conversions():
         RapidOcrOptions(),
         EasyOcrOptions(force_full_page_ocr=True),
         TesseractOcrOptions(force_full_page_ocr=True),
+        TesseractOcrOptions(force_full_page_ocr=True, lang=["auto"]),
         TesseractCliOcrOptions(force_full_page_ocr=True),
         RapidOcrOptions(force_full_page_ocr=True),
     ]
@@ -70,7 +71,9 @@ def test_e2e_conversions():
         engines.append(OcrMacOptions(force_full_page_ocr=True))
 
     for ocr_options in engines:
-        print(f"Converting with ocr_engine: {ocr_options.kind}")
+        print(
+            f"Converting with ocr_engine: {ocr_options.kind}, language: {ocr_options.lang}"
+        )
         converter = get_converter(ocr_options=ocr_options)
         for pdf_path in pdf_paths:
             print(f"converting {pdf_path}")


### PR DESCRIPTION
Add language-agnostic OCR option for TesseractOcr module. It is invoked when the language option is set to `['auto']`. For more context, see the discussion: https://github.com/DS4SD/docling/discussions/640

Please let me know what you think.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
