### PR TITLE
feat: Introduce automatic language detection in TesseractOcrCliModel

### DIFF
--- a/docling/models/tesseract_ocr_model.py
+++ b/docling/models/tesseract_ocr_model.py
@@ -8,6 +8,7 @@ from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import TesseractOcrOptions
 from docling.datamodel.settings import settings
 from docling.models.base_ocr_model import BaseOcrModel
+from docling.utils.ocr_utils import map_tesseract_script
 from docling.utils.profiling import TimeRecorder
 
 _log = logging.getLogger(__name__)
@@ -128,14 +129,7 @@ class TesseractOcrModel(BaseOcrModel):
                                 continue
 
                             script = osd["script_name"]
-
-                            if script == "Katakana" or script == "Hiragana":
-                                script = "Japanese"
-                            elif script == "Han":
-                                script = "HanS"
-                            elif script == "Korean":
-                                script = "Hangul"
-
+                            script = map_tesseract_script(script)
                             _log.debug(
                                 f'Using model for the detected script "{script}"'
                             )

--- a/docling/models/tesseract_ocr_model.py
+++ b/docling/models/tesseract_ocr_model.py
@@ -21,6 +21,7 @@ class TesseractOcrModel(BaseOcrModel):
 
         self.scale = 3  # multiplier for 72 dpi == 216 dpi.
         self.reader = None
+        self.osd_reader = None
 
         if self.enabled:
             install_errmsg = (
@@ -48,8 +49,8 @@ class TesseractOcrModel(BaseOcrModel):
             except:
                 raise ImportError(install_errmsg)
 
-            _, tesserocr_languages = tesserocr.get_languages()
-            if not tesserocr_languages:
+            _, self._tesserocr_languages = tesserocr.get_languages()
+            if not self._tesserocr_languages:
                 raise ImportError(missing_langs_errmsg)
 
             # Initialize the tesseractAPI
@@ -58,7 +59,7 @@ class TesseractOcrModel(BaseOcrModel):
 
             self.script_readers: dict[str, tesserocr.PyTessBaseAPI] = {}
 
-            if any([l.startswith("script/") for l in tesserocr_languages]):
+            if any([l.startswith("script/") for l in self._tesserocr_languages]):
                 self.script_prefix = "script/"
             else:
                 self.script_prefix = ""
@@ -73,14 +74,14 @@ class TesseractOcrModel(BaseOcrModel):
                 tesserocr_kwargs["path"] = self.options.path
 
             if lang == "auto":
-                self.reader = tesserocr.PyTessBaseAPI(
+                self.reader = tesserocr.PyTessBaseAPI(**tesserocr_kwargs)
+                self.osd_reader = tesserocr.PyTessBaseAPI(
                     **{"lang": "osd", "psm": tesserocr.PSM.OSD_ONLY} | tesserocr_kwargs
                 )
             else:
                 self.reader = tesserocr.PyTessBaseAPI(
                     **{"lang": lang} | tesserocr_kwargs,
                 )
-
             self.reader_RIL = tesserocr.RIL
 
     def __del__(self):
@@ -97,8 +98,6 @@ class TesseractOcrModel(BaseOcrModel):
             yield from page_batch
             return
 
-        import tesserocr
-
         for page in page_batch:
             assert page._backend is not None
             if not page._backend.is_valid():
@@ -106,6 +105,7 @@ class TesseractOcrModel(BaseOcrModel):
             else:
                 with TimeRecorder(conv_res, "ocr"):
                     assert self.reader is not None
+                    assert self._tesserocr_languages is not None
 
                     ocr_rects = self.get_ocr_rects(page)
 
@@ -118,11 +118,12 @@ class TesseractOcrModel(BaseOcrModel):
                             scale=self.scale, cropbox=ocr_rect
                         )
 
-                        # Retrieve text snippets with their bounding boxes
-                        self.reader.SetImage(high_res_image)
+                        local_reader = self.reader
+                        if "auto" in self.options.lang:
+                            assert self.osd_reader is not None
 
-                        if self.options.lang == ["auto"]:
-                            osd = self.reader.DetectOrientationScript()
+                            self.osd_reader.SetImage(high_res_image)
+                            osd = self.osd_reader.DetectOrientationScript()
 
                             # No text, probably
                             if osd is None:
@@ -130,24 +131,29 @@ class TesseractOcrModel(BaseOcrModel):
 
                             script = osd["script_name"]
                             script = map_tesseract_script(script)
-                            _log.debug(
-                                f'Using model for the detected script "{script}"'
-                            )
+                            lang = f"{self.script_prefix}{script}"
 
-                            if script not in self.script_readers:
-                                self.script_readers[script] = tesserocr.PyTessBaseAPI(
-                                    path=self.reader.GetDatapath(),
-                                    lang=f"{self.script_prefix}{script}",
-                                    psm=tesserocr.PSM.AUTO,
-                                    init=True,
-                                    oem=tesserocr.OEM.DEFAULT,
-                                )
+                            # Check if the detected languge is present in the system
+                            if lang not in self._tesserocr_languages:
+                                msg = f"Tesseract detected the script '{script}' and language '{lang}'."
+                                msg += " However this language is not installed in your system and will be ignored."
+                                _log.warning(msg)
+                            else:
+                                if script not in self.script_readers:
+                                    import tesserocr
 
-                            local_reader = self.script_readers[script]
-                            local_reader.SetImage(high_res_image)
-                        else:
-                            local_reader = self.reader
+                                    self.script_readers[script] = (
+                                        tesserocr.PyTessBaseAPI(
+                                            path=self.reader.GetDatapath(),
+                                            lang=lang,
+                                            psm=tesserocr.PSM.AUTO,
+                                            init=True,
+                                            oem=tesserocr.OEM.DEFAULT,
+                                        )
+                                    )
+                                local_reader = self.script_readers[script]
 
+                        local_reader.SetImage(high_res_image)
                         boxes = local_reader.GetComponentImages(
                             self.reader_RIL.TEXTLINE, True
                         )

--- a/docling/utils/ocr_utils.py
+++ b/docling/utils/ocr_utils.py
@@ -1,0 +1,9 @@
+def map_tesseract_script(script: str) -> str:
+    r""" """
+    if script == "Katakana" or script == "Hiragana":
+        script = "Japanese"
+    elif script == "Han":
+        script = "HanS"
+    elif script == "Korean":
+        script = "Hangul"
+    return script

--- a/docs/examples/tesseract_lang_detection.py
+++ b/docs/examples/tesseract_lang_detection.py
@@ -16,7 +16,9 @@ def main():
     # ocr_options = TesseractOcrOptions(lang=["auto"])
     ocr_options = TesseractCliOcrOptions(lang=["auto"])
 
-    pipeline_options = PdfPipelineOptions(do_ocr=True, ocr_options=ocr_options)
+    pipeline_options = PdfPipelineOptions(
+        do_ocr=True, force_full_page_ocr=True, ocr_options=ocr_options
+    )
 
     converter = DocumentConverter(
         format_options={

--- a/docs/examples/tesseract_lang_detection.py
+++ b/docs/examples/tesseract_lang_detection.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import (
+    PdfPipelineOptions,
+    TesseractCliOcrOptions,
+    TesseractOcrOptions,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
+
+
+def main():
+    input_doc = Path("./tests/data/2206.01062.pdf")
+
+    # Set lang=["auto"] with a tesseract OCR engine: TesseractOcrOptions, TesseractCliOcrOptions
+    # ocr_options = TesseractOcrOptions(lang=["auto"])
+    ocr_options = TesseractCliOcrOptions(lang=["auto"])
+
+    pipeline_options = PdfPipelineOptions(do_ocr=True, ocr_options=ocr_options)
+
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options,
+            )
+        }
+    )
+
+    doc = converter.convert(input_doc).document
+    md = doc.export_to_markdown()
+    print(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - "Table export": examples/export_tables.py
       - "Multimodal export": examples/export_multimodal.py
       - "Force full page OCR": examples/full_page_ocr.py
+      - "Automatic OCR language detection with tesseract": examples/tesseract_lang_detection.py
       - "Accelerator options": examples/run_with_accelerator.py
       - "Simple translation": examples/translate.py      
     - ✂️ Chunking:

--- a/tests/test_e2e_ocr_conversion.py
+++ b/tests/test_e2e_ocr_conversion.py
@@ -62,6 +62,7 @@ def test_e2e_conversions():
         TesseractOcrOptions(force_full_page_ocr=True),
         TesseractOcrOptions(force_full_page_ocr=True, lang=["auto"]),
         TesseractCliOcrOptions(force_full_page_ocr=True),
+        TesseractCliOcrOptions(force_full_page_ocr=True, lang=["auto"]),
         RapidOcrOptions(force_full_page_ocr=True),
     ]
 


### PR DESCRIPTION
Introduce automatic language detection for the `TesseractOcrCliModel`.
The language detection mode is enabled when `lang == "auto"`

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
