### PR TITLE
docs(backend XML): do not delete temp file in notebook

### DIFF
--- a/docs/examples/backend_xml_rag.ipynb
+++ b/docs/examples/backend_xml_rag.ipynb
@@ -49,7 +49,6 @@
     "  - [Fetch the data](#fetch-the-data) from USPTO and PubMed Central® sites, using Docling custom backends\n",
     "  - [Parse, chunk, and index](#parse-chunk-and-index) the documents in a vector database\n",
     "  - [Perform RAG](#question-answering-with-rag) using [LlamaIndex Docling extension](../../integrations/llamaindex/)\n",
-    "  - [Delete the temporary files](#delete-temporary-files) used in notebook\n",
     "\n",
     "For more details on document chunking with Docling, refer to the [Chunking](../../concepts/chunking/) documentation. For RAG with Docling and LlamaIndex, also check the example [RAG with LlamaIndex](../rag_llamaindex/)."
    ]
@@ -1031,26 +1030,6 @@
     "        border_style=\"bold green\",\n",
     "    )\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Delete temporary files\n",
-    "\n",
-    "The XML files used in this notebook, as well as the Milvus local database will be removed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import shutil\n",
-    "\n",
-    "shutil.rmtree(TEMP_DIR)"
    ]
   }
  ],


### PR DESCRIPTION
A small addition for commit 4df08bec32b4f98a45c14ae758e0989c13891a03 after remark https://github.com/DS4SD/docling/pull/788#discussion_r1928347300 from @vagenas 

> Since TEMP_DIR is anyway defined as temporary directory (i.e. will be removed upon restart), this part can also be dropped for simplicity (and to avoid any accidents with folder deletions..)