### PR TITLE
fix: use file extension if filetype fails with PDF

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -352,6 +352,8 @@ class _DocumentConversionInput(BaseModel):
             mime = FormatToMimeType[InputFormat.MD][0]
         elif ext in FormatToExtensions[InputFormat.JSON_DOCLING]:
             mime = FormatToMimeType[InputFormat.JSON_DOCLING][0]
+        elif ext in FormatToExtensions[InputFormat.PDF]:
+            mime = FormatToMimeType[InputFormat.PDF][0]
         return mime
 
     @staticmethod


### PR DESCRIPTION
`filetype` library may not identify some files as PDF, for instance https://github.com/user-attachments/files/18533486/WMOOS6EVZZXGYSVQPP7UORUTNEUEBO3Q.pdf.
As a simple solution, we can leverage `_DocumentConversionInput._mime_from_extension` function and the file extension, following the current pattern with other MIME types. 

Resolves DS4SD/docling#798

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
