### PR TITLE
fix(msword_backend): handle conversion error in label parsing

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -242,7 +242,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             parts = label.split(":")
 
             if len(parts) == 2:
-                return parts[0], int(parts[1])
+                return parts[0], self.str_to_int(parts[1], None)
 
         parts = self.split_text_and_number(label)
 


### PR DESCRIPTION
**Description:**  
**fix(msword_backend):** Handle conversion error in label parsing

Updated the label parsing logic to use `str_to_int` with a default value, preventing potential conversion errors when unexpected formats are encountered.

**Steps to Reproduce:**  
The issue can be reproduced using the attached document, which contains a paragraph style: *"Shell title: Table and Figure"*.

**Code to Reproduce:**
```python
from docling.document_converter import DocumentConverter

converter = DocumentConverter()
_ = converter.convert("issue_paragraph_style.docx")
```

**Attachment:**  
[issue_paragraph_style.docx](https://github.com/user-attachments/files/18672491/issue_paragraph_style.docx)

---

**PS:** Thank you for this excellent package!

---

**Checklist:**

- [ ] Documentation has been updated, if necessary.  
- [ ] Examples have been added, if necessary.  
- [ ] Tests have been added, if necessary.  

---


