### PR TITLE
refactor: use org--name in artifacts-path

### DIFF
--- a/docling/models/code_formula_model.py
+++ b/docling/models/code_formula_model.py
@@ -62,7 +62,7 @@ class CodeFormulaModel(BaseItemAndImageEnrichmentModel):
         Processes the given batch of elements and enriches them with predictions.
     """
 
-    _model_repo_folder = "CodeFormula"
+    _model_repo_folder = "ds4sd--CodeFormula"
     elements_batch_size = 5
     images_scale = 1.66  # = 120 dpi, aligned with training data resolution
     expansion_factor = 0.03

--- a/docling/models/document_picture_classifier.py
+++ b/docling/models/document_picture_classifier.py
@@ -56,7 +56,7 @@ class DocumentPictureClassifier(BaseEnrichmentModel):
         Processes a batch of elements and adds classification annotations.
     """
 
-    _model_repo_folder = "DocumentFigureClassifier"
+    _model_repo_folder = "ds4sd--DocumentFigureClassifier"
     images_scale = 2
 
     def __init__(

--- a/docling/models/layout_model.py
+++ b/docling/models/layout_model.py
@@ -22,7 +22,7 @@ _log = logging.getLogger(__name__)
 
 
 class LayoutModel(BasePageModel):
-    _model_repo_folder = "docling-models"
+    _model_repo_folder = "ds4sd--docling-models"
     _model_path = "model_artifacts/layout"
 
     TEXT_ELEM_LABELS = [

--- a/docling/models/table_structure_model.py
+++ b/docling/models/table_structure_model.py
@@ -23,7 +23,7 @@ from docling.utils.profiling import TimeRecorder
 
 
 class TableStructureModel(BasePageModel):
-    _model_repo_folder = "docling-models"
+    _model_repo_folder = "ds4sd--docling-models"
     _model_path = "model_artifacts/tableformer"
 
     def __init__(


### PR DESCRIPTION
Make sure to use the full `repo_id` in the downloaded artifacts.

We use the same semantics of HF: `org--name`.


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
