### PR TITLE
fix: remove unused httpx

### DIFF
--- a/docling/models/easyocr_model.py
+++ b/docling/models/easyocr_model.py
@@ -4,9 +4,7 @@ import zipfile
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-import httpx
 import numpy
-import torch
 from docling_core.types.doc import BoundingBox, CoordOrigin
 
 from docling.datamodel.base_models import Cell, OcrCell, Page

--- a/docling/models/picture_description_api_model.py
+++ b/docling/models/picture_description_api_model.py
@@ -3,7 +3,7 @@ import io
 import logging
 from typing import Iterable, List, Optional
 
-import httpx
+import requests
 from docling_core.types.doc import PictureItem
 from docling_core.types.doc.document import (  # TODO: move import to docling_core.types.doc
     PictureDescriptionData,
@@ -90,13 +90,13 @@ class PictureDescriptionApiModel(PictureDescriptionBaseModel):
                 **self.options.params,
             }
 
-            r = httpx.post(
+            r = requests.post(
                 str(self.options.url),
                 headers=self.options.headers,
                 json=payload,
                 timeout=self.options.timeout,
             )
-            if not r.is_success:
+            if not r.ok:
                 _log.error(f"Error calling the API. Reponse was {r.text}")
             r.raise_for_status()
 

--- a/docling/models/picture_description_api_model.py
+++ b/docling/models/picture_description_api_model.py
@@ -4,10 +4,6 @@ import logging
 from typing import Iterable, List, Optional
 
 import requests
-from docling_core.types.doc import PictureItem
-from docling_core.types.doc.document import (  # TODO: move import to docling_core.types.doc
-    PictureDescriptionData,
-)
 from PIL import Image
 from pydantic import BaseModel, ConfigDict
 


### PR DESCRIPTION
`httpx` is imported and not used

**Issue resolved by this Pull Request:**
Resolves #918

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
