### PR TITLE
test: avoid testing exact JSON

### DIFF
--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 
@@ -11,6 +10,8 @@ from docling.datamodel.document import (
     SectionHeaderItem,
 )
 from docling.document_converter import DocumentConverter
+
+from .verify_utils import verify_document
 
 GENERATE = False
 
@@ -66,7 +67,7 @@ def verify_export(pred_text: str, gtfile: str):
         return True
 
     else:
-        with open(gtfile, "r") as fr:
+        with open(gtfile) as fr:
             true_text = fr.read()
 
         assert pred_text == true_text, f"pred_text!=true_text for {gtfile}"
@@ -99,5 +100,4 @@ def test_e2e_html_conversions():
             pred_itxt, str(gt_path) + ".itxt"
         ), "export to indented-text"
 
-        pred_json: str = json.dumps(doc.export_to_dict(), indent=2)
-        assert verify_export(pred_json, str(gt_path) + ".json"), "export to json"
+        assert verify_document(doc, str(gt_path) + ".json", GENERATE)

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -1,4 +1,3 @@
-import json
 import os
 from io import BytesIO
 from pathlib import Path
@@ -8,6 +7,8 @@ from docling_core.types.doc import DoclingDocument
 from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.datamodel.document import ConversionResult
 from docling.document_converter import DocumentConverter
+
+from .verify_utils import verify_document
 
 GENERATE = False
 
@@ -61,8 +62,7 @@ def test_e2e_pubmed_conversions(use_stream=False):
             pred_itxt, str(gt_path) + ".itxt"
         ), "export to indented-text"
 
-        pred_json: str = json.dumps(doc.export_to_dict(), indent=2)
-        assert verify_export(pred_json, str(gt_path) + ".json"), "export to json"
+        assert verify_document(doc, str(gt_path) + ".json", GENERATE), "export to json"
 
 
 def test_e2e_pubmed_conversions_stream():

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 
@@ -6,7 +5,7 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_docitems
+from .verify_utils import verify_document
 
 GENERATE = False
 
@@ -44,20 +43,6 @@ def verify_export(pred_text: str, gtfile: str):
         return pred_text == true_text
 
 
-def verify_document(pred_doc: DoclingDocument, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            json.dump(pred_doc.export_to_dict(), fw, indent=2)
-
-        return True
-    else:
-        with open(gtfile, "r") as fr:
-            true_doc = DoclingDocument.model_validate_json(fr.read())
-
-        return verify_docitems(pred_doc, true_doc, fuzzy=False)
-
-
 def test_e2e_xlsx_conversions():
 
     xlsx_paths = get_xlsx_paths()
@@ -84,4 +69,6 @@ def test_e2e_xlsx_conversions():
             pred_itxt, str(gt_path) + ".itxt"
         ), "export to indented-text"
 
-        assert verify_document(doc, str(gt_path) + ".json"), "document document"
+        assert verify_document(
+            doc, str(gt_path) + ".json", GENERATE
+        ), "document document"

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 
@@ -12,7 +11,7 @@ from docling.datamodel.document import (
 )
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_docitems
+from .verify_utils import verify_document
 
 GENERATE = False
 
@@ -74,20 +73,6 @@ def verify_export(pred_text: str, gtfile: str):
         return pred_text == true_text
 
 
-def verify_document(pred_doc: DoclingDocument, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            json.dump(pred_doc.export_to_dict(), fw, indent=2)
-
-        return True
-    else:
-        with open(gtfile, "r") as fr:
-            true_doc = DoclingDocument.model_validate_json(fr.read())
-
-        return verify_docitems(pred_doc, true_doc, fuzzy=False)
-
-
 def test_e2e_docx_conversions():
 
     docx_paths = get_docx_paths()
@@ -114,7 +99,9 @@ def test_e2e_docx_conversions():
             pred_itxt, str(gt_path) + ".itxt"
         ), "export to indented-text"
 
-        assert verify_document(doc, str(gt_path) + ".json"), "document document"
+        assert verify_document(
+            doc, str(gt_path) + ".json", GENERATE
+        ), "document document"
 
         if docx_path.name == "word_tables.docx":
             pred_html: str = doc.export_to_html()

--- a/tests/test_backend_patent_uspto.py
+++ b/tests/test_backend_patent_uspto.py
@@ -1,6 +1,5 @@
 """Test methods in module docling.backend.patent_uspto_backend.py."""
 
-import json
 import logging
 import os
 from pathlib import Path
@@ -13,6 +12,8 @@ from docling_core.types.doc import DocItemLabel, TableData, TextItem
 from docling.backend.xml.uspto_backend import PatentUsptoDocumentBackend, XmlTable
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
+
+from .verify_utils import verify_document
 
 GENERATE: bool = False
 DATA_PATH: Path = Path("./tests/data/uspto/")
@@ -110,12 +111,11 @@ def test_patent_groundtruth(patents, groundtruth):
             assert (
                 pred_md == gt_names[md_name]
             ), f"Markdown file mismatch against groundtruth {md_name}"
-        json_name = path.stem + ".json"
-        if json_name in gt_names:
-            pred_json = json.dumps(doc.export_to_dict(), indent=2)
-            assert (
-                pred_json == gt_names[json_name]
-            ), f"JSON file mismatch against groundtruth {json_name}"
+        json_path = path.with_suffix(".json")
+        if json_path.stem in gt_names:
+            assert verify_document(
+                doc, str(json_path), False
+            ), f"JSON file mismatch against groundtruth {json_path}"
         itxt_name = path.stem + ".itxt"
         if itxt_name in gt_names:
             pred_itxt = doc._export_to_indented_text()

--- a/tests/test_backend_pptx.py
+++ b/tests/test_backend_pptx.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 
@@ -6,7 +5,7 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_docitems
+from .verify_utils import verify_document
 
 GENERATE = False
 
@@ -44,20 +43,6 @@ def verify_export(pred_text: str, gtfile: str):
         return pred_text == true_text
 
 
-def verify_document(pred_doc: DoclingDocument, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            json.dump(pred_doc.export_to_dict(), fw, indent=2)
-
-        return True
-    else:
-        with open(gtfile, "r") as fr:
-            true_doc = DoclingDocument.model_validate_json(fr.read())
-
-        return verify_docitems(pred_doc, true_doc, fuzzy=False)
-
-
 def test_e2e_pptx_conversions():
 
     pptx_paths = get_pptx_paths()
@@ -84,4 +69,6 @@ def test_e2e_pptx_conversions():
             pred_itxt, str(gt_path) + ".itxt"
         ), "export to indented-text"
 
-        assert verify_document(doc, str(gt_path) + ".json"), "document document"
+        assert verify_document(
+            doc, str(gt_path) + ".json", GENERATE
+        ), "document document"

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import warnings
 from pathlib import Path
 from typing import List, Optional
@@ -457,3 +458,17 @@ def verify_conversion_result_v2(
         assert verify_dt(
             doc_pred_dt, doc_true_dt, fuzzy=fuzzy
         ), f"Mismatch in DocTags prediction for {input_path}"
+
+
+def verify_document(pred_doc: DoclingDocument, gtfile: str, generate: bool = False):
+
+    if not os.path.exists(gtfile) or generate:
+        with open(gtfile, "w") as fw:
+            json.dump(pred_doc.export_to_dict(), fw, indent=2)
+
+        return True
+    else:
+        with open(gtfile) as fr:
+            true_doc = DoclingDocument.model_validate_json(fr.read())
+
+        return verify_docitems(pred_doc, true_doc, fuzzy=False)


### PR DESCRIPTION
### Description

The main purpose of this PR is to avoid using exact matches between predicted and ground truth JSON formats of converted files by HTML and XML backends. As explained in issue #1022 , a helper function is used for this type of tests.
In detail:

- Avoid testing exact JSON output in html and xml backends.
- Reuse the JSON verify helper function among backend test files.
- Improve type annotations in html backend.

**Issue resolved by this Pull Request:**
Partially _resolves_ #1022 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
