### PR TITLE
test: avoid testing exact JSON in CSV backend

### DIFF
--- a/tests/test_backend_csv.py
+++ b/tests/test_backend_csv.py
@@ -8,7 +8,7 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_export
+from .verify_utils import verify_document, verify_export
 
 GENERATE = False
 
@@ -58,8 +58,7 @@ def test_e2e_valid_csv_conversions():
             pred_itxt, str(gt_path) + ".itxt"
         ), "export to indented-text"
 
-        pred_json: str = json.dumps(doc.export_to_dict(), indent=2)
-        assert verify_export(pred_json, str(gt_path) + ".json"), "export to json"
+        assert verify_document(doc, str(gt_path) + ".json"), "export to json"
 
 
 def test_e2e_invalid_csv_conversions():

--- a/tests/test_backend_csv.py
+++ b/tests/test_backend_csv.py
@@ -8,6 +8,8 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
 from docling.document_converter import DocumentConverter
 
+from .verify_utils import verify_export
+
 GENERATE = False
 
 
@@ -31,22 +33,6 @@ def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.CSV])
 
     return converter
-
-
-def verify_export(pred_text: str, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            fw.write(pred_text)
-
-        return True
-
-    else:
-        with open(gtfile, "r") as fr:
-            true_text = fr.read()
-
-        assert pred_text == true_text, "pred_itxt==true_itxt"
-        return pred_text == true_text
 
 
 def test_e2e_valid_csv_conversions():

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -11,7 +11,7 @@ from docling.datamodel.document import (
 )
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_document
+from .verify_utils import verify_document, verify_export
 
 GENERATE = False
 
@@ -56,22 +56,6 @@ def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.HTML])
 
     return converter
-
-
-def verify_export(pred_text: str, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            fw.write(pred_text)
-
-        return True
-
-    else:
-        with open(gtfile) as fr:
-            true_text = fr.read()
-
-        assert pred_text == true_text, f"pred_text!=true_text for {gtfile}"
-        return pred_text == true_text
 
 
 def test_e2e_html_conversions():

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -8,7 +8,7 @@ from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.datamodel.document import ConversionResult
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_document
+from .verify_utils import verify_document, verify_export
 
 GENERATE = False
 
@@ -22,18 +22,6 @@ def get_pubmed_paths():
 def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.XML_JATS])
     return converter
-
-
-def verify_export(pred_text: str, gtfile: str):
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            fw.write(pred_text)
-        return True
-    else:
-        with open(gtfile, "r") as fr:
-            true_text = fr.read()
-        assert pred_text == true_text, f"pred_text!=true_text for {gtfile}"
-        return pred_text == true_text
 
 
 def test_e2e_pubmed_conversions(use_stream=False):

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -5,7 +5,7 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_document
+from .verify_utils import verify_document, verify_export
 
 GENERATE = False
 
@@ -25,22 +25,6 @@ def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.XLSX])
 
     return converter
-
-
-def verify_export(pred_text: str, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            fw.write(pred_text)
-
-        return True
-
-    else:
-        with open(gtfile, "r") as fr:
-            true_text = fr.read()
-
-        assert pred_text == true_text, "pred_itxt==true_itxt"
-        return pred_text == true_text
 
 
 def test_e2e_xlsx_conversions():

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -11,7 +11,7 @@ from docling.datamodel.document import (
 )
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_document
+from .verify_utils import verify_document, verify_export
 
 GENERATE = False
 
@@ -56,21 +56,6 @@ def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.DOCX])
 
     return converter
-
-
-def verify_export(pred_text: str, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            fw.write(pred_text)
-
-        return True
-
-    else:
-        with open(gtfile, "r") as fr:
-            true_text = fr.read()
-
-        return pred_text == true_text
 
 
 def test_e2e_docx_conversions():

--- a/tests/test_backend_pptx.py
+++ b/tests/test_backend_pptx.py
@@ -5,7 +5,7 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
 from docling.document_converter import DocumentConverter
 
-from .verify_utils import verify_document
+from .verify_utils import verify_document, verify_export
 
 GENERATE = False
 
@@ -25,22 +25,6 @@ def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.PPTX])
 
     return converter
-
-
-def verify_export(pred_text: str, gtfile: str):
-
-    if not os.path.exists(gtfile) or GENERATE:
-        with open(gtfile, "w") as fw:
-            fw.write(pred_text)
-
-        return True
-
-    else:
-        with open(gtfile, "r") as fr:
-            true_text = fr.read()
-
-        assert pred_text == true_text, "pred_itxt==true_itxt"
-        return pred_text == true_text
 
 
 def test_e2e_pptx_conversions():

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -472,3 +472,17 @@ def verify_document(pred_doc: DoclingDocument, gtfile: str, generate: bool = Fal
             true_doc = DoclingDocument.model_validate_json(fr.read())
 
         return verify_docitems(pred_doc, true_doc, fuzzy=False)
+
+
+def verify_export(pred_text: str, gtfile: str, generate: bool = False) -> bool:
+    file = Path(gtfile)
+
+    if not file.exists() or generate:
+        with file.open("w") as fw:
+            fw.write(pred_text)
+        return True
+
+    with file.open("r") as fr:
+        true_text = fr.read()
+
+    return pred_text == true_text


### PR DESCRIPTION
# Descriptions  
The main context of this PR is solving issue #1022, the CSV backend tests is validating the exact JSON.  

- Update tests for CSV backends to avoid testing exact JSON comparisons.  
- Refactor `verify_export` to use `pathlib`.  
- Reuse the new `verify_export` function in tests.  

**Checklist:**  

- [x] Documentation has been updated, if necessary.  
- [x] Examples have been added, if necessary.  
- [x] Tests have been added, if necessary.  
