### PR TITLE
fix(html): use 'start' attribute when parsing ordered lists from HTML docs

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -281,7 +281,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
         parent = self.parents[self.level]
         if parent is None:
-            _log.warning(f"list-item has no parent in DoclingDocument: {element}")
+            _log.debug(f"list-item has no parent in DoclingDocument: {element}")
             return
         parent_label: str = parent.label
         index_in_list = len(parent.children) + 1
@@ -338,13 +338,13 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                 parent=parent,
             )
         else:
-            _log.warning(f"list-item has no text: {element}")
+            _log.debug(f"list-item has no text: {element}")
 
     @staticmethod
     def parse_table_data(element: Tag) -> Optional[TableData]:
         nested_tables = element.find("table")
         if nested_tables is not None:
-            _log.warning("Skipping nested table.")
+            _log.debug("Skipping nested table.")
             return None
 
         # Count the number of rows (number of <tr> elements)


### PR DESCRIPTION
### Description

This PR is about leveraging the `start` attribute in HTML `<ol>` tags (ordered lists) when parsing HTML documents.

In HTML documents, items in ordered lists are always parsed using numbers starting with 1 followed by a period as markers. The export to markdown is therefore simplified, since this notation correspond to the basic syntax in markdown.

However HTML allows ordered lists to start with another number, if indicated by the attribute `start`. Even though the markdown basic syntax recommend to always start with the number 1, applications like GitHub Flavored Markdown usually accept other starting numbers.

In this PR, the HTML backend creates ordered lists starting with the number indicated in `start` attribute, if it exists.

**Issue resolved by this Pull Request:**
Resolves #1058 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
