### PR TITLE
fix(html): handle nested empty lists

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -134,7 +134,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     self.analyze_tag(cast(Tag, element), doc)
                 except Exception as exc_child:
                     _log.error(
-                        f"Error processing child from tag{tag.name}: {exc_child}"
+                        f"Error processing child from tag {tag.name}: {repr(exc_child)}"
                     )
                     raise exc_child
             elif isinstance(element, NavigableString) and not isinstance(
@@ -347,11 +347,11 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     content_layer=self.content_layer,
                 )
                 self.level += 1
-
-            self.walk(element, doc)
-
-            self.parents[self.level + 1] = None
-            self.level -= 1
+                self.walk(element, doc)
+                self.parents[self.level + 1] = None
+                self.level -= 1
+            else:
+                self.walk(element, doc)
 
         elif element.text.strip():
             text = element.text.strip()

--- a/tests/data/groundtruth/docling_v2/example_07.html.itxt
+++ b/tests/data/groundtruth/docling_v2/example_07.html.itxt
@@ -1,0 +1,22 @@
+item-0 at level 0: unspecified: group _root_
+  item-1 at level 1: list: group list
+    item-2 at level 2: list_item: Asia
+      item-3 at level 3: list: group list
+        item-4 at level 4: list_item: China
+        item-5 at level 4: list_item: Japan
+        item-6 at level 4: list_item: Thailand
+    item-7 at level 2: list_item: Europe
+      item-8 at level 3: list: group list
+        item-9 at level 4: list_item: UK
+        item-10 at level 4: list_item: Germany
+        item-11 at level 4: list_item: Switzerland
+          item-12 at level 5: list: group list
+            item-13 at level 6: list: group list
+              item-14 at level 7: list_item: Bern
+              item-15 at level 7: list_item: Aargau
+        item-16 at level 4: list_item: Italy
+          item-17 at level 5: list: group list
+            item-18 at level 6: list: group list
+              item-19 at level 7: list_item: Piedmont
+              item-20 at level 7: list_item: Liguria
+    item-21 at level 2: list_item: Africa

--- a/tests/data/groundtruth/docling_v2/example_07.html.json
+++ b/tests/data/groundtruth/docling_v2/example_07.html.json
@@ -1,0 +1,374 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.2.0",
+  "name": "example_07",
+  "origin": {
+    "mimetype": "text/html",
+    "binary_hash": 623628706615267627,
+    "filename": "example_07.html"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/groups/0"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [
+    {
+      "self_ref": "#/groups/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/0"
+        },
+        {
+          "$ref": "#/texts/4"
+        },
+        {
+          "$ref": "#/texts/13"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/1",
+      "parent": {
+        "$ref": "#/texts/0"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/1"
+        },
+        {
+          "$ref": "#/texts/2"
+        },
+        {
+          "$ref": "#/texts/3"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/2",
+      "parent": {
+        "$ref": "#/texts/4"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/5"
+        },
+        {
+          "$ref": "#/texts/6"
+        },
+        {
+          "$ref": "#/texts/7"
+        },
+        {
+          "$ref": "#/texts/10"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/3",
+      "parent": {
+        "$ref": "#/texts/7"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/4"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/4",
+      "parent": {
+        "$ref": "#/groups/3"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/8"
+        },
+        {
+          "$ref": "#/texts/9"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/5",
+      "parent": {
+        "$ref": "#/texts/10"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/6"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/6",
+      "parent": {
+        "$ref": "#/groups/5"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/11"
+        },
+        {
+          "$ref": "#/texts/12"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    }
+  ],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/1"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Asia",
+      "text": "Asia",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "China",
+      "text": "China",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Japan",
+      "text": "Japan",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Thailand",
+      "text": "Thailand",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/2"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Europe",
+      "text": "Europe",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "UK",
+      "text": "UK",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Germany",
+      "text": "Germany",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/3"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Switzerland",
+      "text": "Switzerland",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
+        "$ref": "#/groups/4"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Bern",
+      "text": "Bern",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/9",
+      "parent": {
+        "$ref": "#/groups/4"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Aargau",
+      "text": "Aargau",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/10",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/5"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Italy",
+      "text": "Italy",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/11",
+      "parent": {
+        "$ref": "#/groups/6"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Piedmont",
+      "text": "Piedmont",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/12",
+      "parent": {
+        "$ref": "#/groups/6"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Liguria",
+      "text": "Liguria",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/13",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Africa",
+      "text": "Africa",
+      "enumerated": false,
+      "marker": "-"
+    }
+  ],
+  "pictures": [],
+  "tables": [],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {}
+}

--- a/tests/data/groundtruth/docling_v2/example_07.html.md
+++ b/tests/data/groundtruth/docling_v2/example_07.html.md
@@ -1,0 +1,14 @@
+- Asia
+    - China
+    - Japan
+    - Thailand
+- Europe
+    - UK
+    - Germany
+    - Switzerland
+            - Bern
+            - Aargau
+    - Italy
+            - Piedmont
+            - Liguria
+- Africa

--- a/tests/data/html/example_07.html
+++ b/tests/data/html/example_07.html
@@ -1,0 +1,40 @@
+<html>
+    <body>
+        <ul>
+            <li>Asia
+                <ul>
+                    <li>China</li>
+                    <li>Japan</li>
+                    <li>Thailand</li>
+                </ul>
+            </li>
+            <li>Europe
+                <ul>
+                    <li>UK</li>
+                    <li>Germany</li>
+                    <li>Switzerland
+                        <ul>
+                            <li style="list-style-type: none;">
+                                <ul>
+                                    <li>Bern</li>
+                                    <li>Aargau</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li>Italy
+                        <ul>
+                            <li style="list-style-type: none;">
+                                <ul>
+                                    <li>Piedmont</li>
+                                    <li>Liguria</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li>Africa</li>
+        </ul>
+    </body>
+</html>


### PR DESCRIPTION
### Description

As shown in the example from issue #1117 , some HTML pages may contain embedded lists where a list is a child of another list, instead of a child of another list item. These cases may result in a `KeyError` exception due to a mishandling of the indentation counter.

This PR addresses the cases above, fixes the bug, and adds an example for the regression tests.

**Issue resolved by this Pull Request:**
Resolves #1117 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
